### PR TITLE
Fix MCP tool registration and Zod record schemas

### DIFF
--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -36,9 +36,9 @@ export const CreatePhoneCallInputSchema = z.object({
       "For this particular call, override the agent version used with this version"
     ),
   direction: z.enum(["inbound", "outbound"]).default("outbound"),
-  metadata: z.record(z.string()).optional(),
+  metadata: z.record(z.string(), z.string()).optional(),
   retellLlmDynamicVariables: z
-    .record(z.string())
+    .record(z.string(), z.string())
     .optional()
     .describe("Dynamic variables to pass to the LLM in key-value pairs"),
   optOutSensitiveDataStorage: z.boolean().optional(),
@@ -48,9 +48,9 @@ export const CreatePhoneCallInputSchema = z.object({
 // Web Call Input Schema
 export const CreateWebCallInputSchema = z.object({
   agentId: z.string().describe("The ID of the agent to use for the call"),
-  metadata: z.record(z.string()).optional(),
+  metadata: z.record(z.string(), z.string()).optional(),
   retellLlmDynamicVariables: z
-    .record(z.string())
+    .record(z.string(), z.string())
     .optional()
     .describe("Dynamic variables to pass to the LLM in key-value pairs"),
   optOutSensitiveDataStorage: z.boolean().optional(),
@@ -69,7 +69,7 @@ export const CallOutputSchema = z.object({
   agent_id: z.string(),
   version: z.number(),
   call_status: CallStatusSchema,
-  metadata: z.record(z.string()).optional(),
+  metadata: z.record(z.string(), z.string()).optional(),
   start_timestamp: z.number().optional(),
   end_timestamp: z.number().optional(),
   transcript: z.string().optional(),
@@ -83,7 +83,7 @@ export const CallOutputSchema = z.object({
         .enum(["Negative", "Positive", "Neutral", "Unknown"])
         .optional(),
       call_successful: z.boolean().optional(),
-      custom_analysis_data: z.record(z.any()).optional(),
+      custom_analysis_data: z.record(z.string(), z.unknown()).optional(),
     })
     .optional(),
   call_cost: z
@@ -121,8 +121,8 @@ export const ListCallsInputSchema = z.object({
 // Update Call Input Schema
 export const UpdateCallInputSchema = z.object({
   callId: z.string().describe("The ID of the call to update"),
-  metadata: z.record(z.string()).optional(),
-  dynamicVariables: z.record(z.string()).optional(),
+  metadata: z.record(z.string(), z.string()).optional(),
+  dynamicVariables: z.record(z.string(), z.string()).optional(),
 });
 
 // Delete Call Input Schema
@@ -438,7 +438,9 @@ export const GetKnowledgeBaseInputSchema = z.object({
 export const AddKnowledgeBaseSourceInputSchema = z.object({
   knowledgeBaseId: z.string().describe("The ID of the knowledge base"),
   sourceType: z.string().describe("Type of the source"),
-  sourceConfig: z.record(z.any()).describe("Configuration for the source"),
+  sourceConfig: z
+    .record(z.string(), z.unknown())
+    .describe("Configuration for the source"),
 });
 
 export const DeleteKnowledgeBaseSourceInputSchema = z.object({
@@ -584,7 +586,7 @@ export const CreateRetellLLMInputSchema = z.object({
               parameters: z
                 .object({
                   type: z.literal("object"),
-                  properties: z.record(z.any()),
+                  properties: z.record(z.string(), z.unknown()),
                   required: z.array(z.string()),
                 })
                 .optional(),
@@ -662,7 +664,7 @@ export const CreateRetellLLMInputSchema = z.object({
     .optional()
     .describe("First utterance said by the agent in the call"),
   default_dynamic_variables: z
-    .record(z.string())
+    .record(z.string(), z.string())
     .optional()
     .describe(
       "Default dynamic variables represented as key-value pairs of strings"
@@ -743,7 +745,7 @@ export const UpdateRetellLLMInputSchema = z.object({
   //   .optional(),
   // starting_state: z.string().nullable().optional(),
   begin_message: z.string().optional(),
-  default_dynamic_variables: z.record(z.string()).optional(),
+  default_dynamic_variables: z.record(z.string(), z.string()).optional(),
   knowledge_base_ids: z.array(z.string()).optional(),
 });
 
@@ -802,7 +804,7 @@ export const RetellLLMOutputSchema = z.object({
   //   .optional(),
   // starting_state: z.string().nullable().optional(),
   begin_message: z.string().nullable().optional(),
-  default_dynamic_variables: z.record(z.string()).nullable().optional(),
+  default_dynamic_variables: z.record(z.string(), z.string()).nullable().optional(),
   knowledge_base_ids: z.array(z.string()).nullable().optional(),
   last_modification_timestamp: z.number(),
 });

--- a/src/tools/agent.ts
+++ b/src/tools/agent.ts
@@ -11,23 +11,24 @@ import {
   transformAgentOutput,
   transformUpdateAgentInput,
 } from "../transformers/index.js";
-import { createToolHandler } from "./utils.js";
+import { createToolHandler, createZeroArgToolHandler } from "./utils.js";
 
 export const registerAgentTools = (server: McpServer, retellClient: Retell) => {
-  server.tool(
+  server.registerTool(
     "list_agents",
-    "Lists all Retell agents",
-    {},
-    createToolHandler(async () => {
+    { description: "Lists all Retell agents" },
+    createZeroArgToolHandler(async () => {
       const agents = await retellClient.agent.list();
       return agents.map(transformAgentOutput);
     })
   );
 
-  server.tool(
+  server.registerTool(
     "create_agent",
-    "Creates a new Retell agent",
-    CreateAgentInputSchema.shape,
+    {
+      description: "Creates a new Retell agent",
+      inputSchema: CreateAgentInputSchema,
+    },
     createToolHandler(async (data) => {
       const createAgentDto = transformAgentInput(data);
       const agent = await retellClient.agent.create(createAgentDto);
@@ -35,10 +36,12 @@ export const registerAgentTools = (server: McpServer, retellClient: Retell) => {
     })
   );
 
-  server.tool(
+  server.registerTool(
     "get_agent",
-    "Gets a Retell agent by ID",
-    GetAgentInputSchema.shape,
+    {
+      description: "Gets a Retell agent by ID",
+      inputSchema: GetAgentInputSchema,
+    },
     createToolHandler(async (data) => {
       try {
         const agent = await retellClient.agent.retrieve(data.agentId);
@@ -53,10 +56,12 @@ export const registerAgentTools = (server: McpServer, retellClient: Retell) => {
     })
   );
 
-  server.tool(
+  server.registerTool(
     "update_agent",
-    "Updates an existing Retell agent",
-    UpdateAgentInputSchema.shape,
+    {
+      description: "Updates an existing Retell agent",
+      inputSchema: UpdateAgentInputSchema,
+    },
     createToolHandler(async (data) => {
       try {
         const agentId = data.agentId;
@@ -78,10 +83,12 @@ export const registerAgentTools = (server: McpServer, retellClient: Retell) => {
     })
   );
 
-  server.tool(
+  server.registerTool(
     "delete_agent",
-    "Deletes a Retell agent",
-    GetAgentInputSchema.shape,
+    {
+      description: "Deletes a Retell agent",
+      inputSchema: GetAgentInputSchema,
+    },
     createToolHandler(async (data) => {
       try {
         await retellClient.agent.delete(data.agentId);
@@ -96,10 +103,12 @@ export const registerAgentTools = (server: McpServer, retellClient: Retell) => {
     })
   );
 
-  server.tool(
+  server.registerTool(
     "get_agent_versions",
-    "Gets all versions of a Retell agent",
-    GetAgentInputSchema.shape,
+    {
+      description: "Gets all versions of a Retell agent",
+      inputSchema: GetAgentInputSchema,
+    },
     createToolHandler(async (data) => {
       try {
         const versions = await retellClient.agent.getVersions(data.agentId);

--- a/src/tools/call.ts
+++ b/src/tools/call.ts
@@ -19,10 +19,12 @@ import {
 import { createToolHandler } from "./utils.js";
 
 export const registerCallTools = (server: McpServer, retellClient: Retell) => {
-  server.tool(
+  server.registerTool(
     "create_phone_call",
-    "Creates a new phone call",
-    CreatePhoneCallInputSchema.shape,
+    {
+      description: "Creates a new phone call",
+      inputSchema: CreatePhoneCallInputSchema,
+    },
     createToolHandler(async (data) => {
       const createCallDto = transformPhoneCallInput(data);
       const call = await retellClient.call.createPhoneCall(createCallDto);
@@ -30,10 +32,12 @@ export const registerCallTools = (server: McpServer, retellClient: Retell) => {
     })
   );
 
-  server.tool(
+  server.registerTool(
     "create_web_call",
-    "Creates a new web call",
-    CreateWebCallInputSchema.shape,
+    {
+      description: "Creates a new web call",
+      inputSchema: CreateWebCallInputSchema,
+    },
     createToolHandler(async (data) => {
       const createCallDto = transformWebCallInput(data);
       const call = await retellClient.call.createWebCall(createCallDto);
@@ -41,10 +45,12 @@ export const registerCallTools = (server: McpServer, retellClient: Retell) => {
     })
   );
 
-  server.tool(
+  server.registerTool(
     "get_call",
-    "Gets a call by ID",
-    GetCallInputSchema.shape,
+    {
+      description: "Gets a call by ID",
+      inputSchema: GetCallInputSchema,
+    },
     createToolHandler(async (data) => {
       try {
         const call = await retellClient.call.retrieve(data.callId);
@@ -59,10 +65,12 @@ export const registerCallTools = (server: McpServer, retellClient: Retell) => {
     })
   );
 
-  server.tool(
+  server.registerTool(
     "list_calls",
-    "Lists all calls",
-    ListCallsInputSchema.shape,
+    {
+      description: "Lists all calls",
+      inputSchema: ListCallsInputSchema,
+    },
     createToolHandler(async (data) => {
       try {
         const listCallsDto = transformListCallsInput(data);
@@ -75,10 +83,12 @@ export const registerCallTools = (server: McpServer, retellClient: Retell) => {
     })
   );
 
-  server.tool(
+  server.registerTool(
     "update_call",
-    "Updates an existing call",
-    UpdateCallInputSchema.shape,
+    {
+      description: "Updates an existing call",
+      inputSchema: UpdateCallInputSchema,
+    },
     createToolHandler(async (data) => {
       try {
         const callId = data.callId;
@@ -95,10 +105,12 @@ export const registerCallTools = (server: McpServer, retellClient: Retell) => {
     })
   );
 
-  server.tool(
+  server.registerTool(
     "delete_call",
-    "Deletes a call",
-    DeleteCallInputSchema.shape,
+    {
+      description: "Deletes a call",
+      inputSchema: DeleteCallInputSchema,
+    },
     createToolHandler(async (data) => {
       try {
         await retellClient.call.delete(data.callId);

--- a/src/tools/phone-number.ts
+++ b/src/tools/phone-number.ts
@@ -7,26 +7,27 @@ import {
   UpdatePhoneNumberInputSchema,
 } from "../schemas/index.js";
 import { transformPhoneNumberOutput } from "../transformers/index.js";
-import { createToolHandler } from "./utils.js";
+import { createToolHandler, createZeroArgToolHandler } from "./utils.js";
 
 export const registerPhoneNumberTools = (
   server: McpServer,
   retellClient: Retell
 ) => {
-  server.tool(
+  server.registerTool(
     "list_phone_numbers",
-    "Lists all Retell phone numbers",
-    {},
-    createToolHandler(async () => {
+    { description: "Lists all Retell phone numbers" },
+    createZeroArgToolHandler(async () => {
       const phoneNumbers = await retellClient.phoneNumber.list();
       return phoneNumbers.map(transformPhoneNumberOutput);
     })
   );
 
-  server.tool(
+  server.registerTool(
     "create_phone_number",
-    "Creates a new phone number",
-    CreatePhoneNumberInputSchema.shape,
+    {
+      description: "Creates a new phone number",
+      inputSchema: CreatePhoneNumberInputSchema,
+    },
     createToolHandler(async (data) => {
       const createPhoneNumberDto = {
         area_code: data.areaCode,
@@ -42,10 +43,12 @@ export const registerPhoneNumberTools = (
     })
   );
 
-  server.tool(
+  server.registerTool(
     "get_phone_number",
-    "Gets details of a specific phone number",
-    GetPhoneNumberInputSchema.shape,
+    {
+      description: "Gets details of a specific phone number",
+      inputSchema: GetPhoneNumberInputSchema,
+    },
     createToolHandler(async (data) => {
       const phoneNumber = await retellClient.phoneNumber.retrieve(
         data.phoneNumber
@@ -54,10 +57,12 @@ export const registerPhoneNumberTools = (
     })
   );
 
-  server.tool(
+  server.registerTool(
     "update_phone_number",
-    "Updates a phone number",
-    UpdatePhoneNumberInputSchema.shape,
+    {
+      description: "Updates a phone number",
+      inputSchema: UpdatePhoneNumberInputSchema,
+    },
     createToolHandler(async (data) => {
       const updatePhoneNumberDto = {
         inbound_agent_id: data.inboundAgentId,
@@ -73,10 +78,12 @@ export const registerPhoneNumberTools = (
     })
   );
 
-  server.tool(
+  server.registerTool(
     "delete_phone_number",
-    "Deletes a phone number",
-    GetPhoneNumberInputSchema.shape,
+    {
+      description: "Deletes a phone number",
+      inputSchema: GetPhoneNumberInputSchema,
+    },
     createToolHandler(async (data) => {
       await retellClient.phoneNumber.delete(data.phoneNumber);
       return {

--- a/src/tools/retell-llm.ts
+++ b/src/tools/retell-llm.ts
@@ -11,26 +11,27 @@ import {
   transformUpdateRetellLLMInput,
   transformRetellLLMOutput,
 } from "../transformers/index.js";
-import { createToolHandler } from "./utils.js";
+import { createToolHandler, createZeroArgToolHandler } from "./utils.js";
 
 export const registerRetellLLMTools = (
   server: McpServer,
   retellClient: Retell
 ) => {
-  server.tool(
+  server.registerTool(
     "list_retell_llms",
-    "Lists all Retell LLMs",
-    {},
-    createToolHandler(async () => {
+    { description: "Lists all Retell LLMs" },
+    createZeroArgToolHandler(async () => {
       const llms = await retellClient.llm.list();
       return llms.map(transformRetellLLMOutput);
     })
   );
 
-  server.tool(
+  server.registerTool(
     "create_retell_llm",
-    "Creates a new Retell LLM",
-    CreateRetellLLMInputSchema.shape,
+    {
+      description: "Creates a new Retell LLM",
+      inputSchema: CreateRetellLLMInputSchema,
+    },
     createToolHandler(async (data) => {
       const createLLMDto = transformRetellLLMInput(data);
       const llm = await retellClient.llm.create(createLLMDto);
@@ -38,10 +39,12 @@ export const registerRetellLLMTools = (
     })
   );
 
-  server.tool(
+  server.registerTool(
     "get_retell_llm",
-    "Gets a Retell LLM by ID",
-    GetRetellLLMInputSchema.shape,
+    {
+      description: "Gets a Retell LLM by ID",
+      inputSchema: GetRetellLLMInputSchema,
+    },
     createToolHandler(async (data) => {
       try {
         const llm = await retellClient.llm.retrieve(data.llmId);
@@ -56,10 +59,12 @@ export const registerRetellLLMTools = (
     })
   );
 
-  server.tool(
+  server.registerTool(
     "update_retell_llm",
-    "Updates an existing Retell LLM",
-    UpdateRetellLLMInputSchema.shape,
+    {
+      description: "Updates an existing Retell LLM",
+      inputSchema: UpdateRetellLLMInputSchema,
+    },
     createToolHandler(async (data) => {
       try {
         const llmId = data.llmId;
@@ -73,10 +78,12 @@ export const registerRetellLLMTools = (
     })
   );
 
-  server.tool(
+  server.registerTool(
     "delete_retell_llm",
-    "Deletes a Retell LLM",
-    GetRetellLLMInputSchema.shape,
+    {
+      description: "Deletes a Retell LLM",
+      inputSchema: GetRetellLLMInputSchema,
+    },
     createToolHandler(async (data) => {
       try {
         await retellClient.llm.delete(data.llmId);

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -1,8 +1,6 @@
-import { z } from "zod";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
-export type ToolResponse = {
-  content: Array<{ type: "text"; text: string }>;
-};
+export type ToolResponse = CallToolResult;
 
 export function createSuccessResponse(data: any): ToolResponse {
   return {
@@ -33,6 +31,20 @@ export function createToolHandler<T>(
   return async (data: T) => {
     try {
       const result = await handler(data);
+      return createSuccessResponse(result);
+    } catch (error) {
+      console.error("Tool execution error:", error);
+      return createErrorResponse(error);
+    }
+  };
+}
+
+export function createZeroArgToolHandler(
+  handler: () => Promise<any>
+): () => Promise<ToolResponse> {
+  return async () => {
+    try {
+      const result = await handler();
       return createSuccessResponse(result);
     } catch (error) {
       console.error("Tool execution error:", error);

--- a/src/tools/voice.ts
+++ b/src/tools/voice.ts
@@ -3,23 +3,24 @@ import Retell from "retell-sdk";
 
 import { GetVoiceInputSchema } from "../schemas/index.js";
 import { transformVoiceOutput } from "../transformers/index.js";
-import { createToolHandler } from "./utils.js";
+import { createToolHandler, createZeroArgToolHandler } from "./utils.js";
 
 export const registerVoiceTools = (server: McpServer, retellClient: Retell) => {
-  server.tool(
+  server.registerTool(
     "list_voices",
-    "Lists all available Retell voices",
-    {},
-    createToolHandler(async () => {
+    { description: "Lists all available Retell voices" },
+    createZeroArgToolHandler(async () => {
       const voices = await retellClient.voice.list();
       return voices.map(transformVoiceOutput);
     })
   );
 
-  server.tool(
+  server.registerTool(
     "get_voice",
-    "Gets details of a specific voice",
-    GetVoiceInputSchema.shape,
+    {
+      description: "Gets details of a specific voice",
+      inputSchema: GetVoiceInputSchema,
+    },
     createToolHandler(async (data) => {
       const voice = await retellClient.voice.retrieve(data.voiceId);
       return transformVoiceOutput(voice);


### PR DESCRIPTION
This fixes tool discovery/registration issues caused by using outdated MCP tool registration patterns and incomplete Zod record schemas.

**What was wrong**

- Tools were still being registered with the older `server.tool(...)` shape
- Zero-argument list tools were not using the current registration style cleanly
- Several schemas used `z.record(...)` in a way that no longer matches current Zod expectations

**What changed**

- Migrated tool definitions to `server.registerTool(...)`
- Added a small zero-argument tool handler helper for list-style tools
- Updated affected `z.record(...)` schemas to use explicit key/value types

**Result**

- Tool registration matches the current MCP SDK API
- Schemas type-check correctly